### PR TITLE
Assign copyright to the project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+Logo design by Konstantin Kudryashov <ever.zet@gmail.com>
+
+Copyright (c) 2013-2016 The PhpSpec Project (http://phpspec.net)
+
 This work is licensed under the Creative Commons Attribution-ShareAlike
 4.0 International License. To view a copy of this license, visit
 http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to


### PR DESCRIPTION
Currently copyright is retained by Konstantin. This means the PhpSpec project should be following the attribution Creative Commons licence.

I think implicitly it's been donated to the project, this change means we don't have to include links etc. attributing Konstanin in any usages.

I added his credits because it's good work and he should get the kudos.

@everzet What do you think of this? Please merge if you're happy reassigning the copyright. We could alternatively have dual holders like PhpSpec itself (e.g. you + the project or some other combination)
